### PR TITLE
Update TestBinary to work on CRLF systems

### DIFF
--- a/internal/util/bin.go
+++ b/internal/util/bin.go
@@ -38,7 +38,7 @@ func TestBinary(name, path string) (version string, _ error) {
 		return "", err
 	}
 
-	pattern, err := regexp.Compile("^" + regexp.QuoteMeta(name) + " version (.+) Copyright .* the FFmpeg developers\n")
+	pattern, err := regexp.Compile("^" + regexp.QuoteMeta(name) + " version (.+) Copyright .* the FFmpeg developers\r?\n")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The regex for detecting the ffmpeg version does not take into account CRLF line endings, I modified it to do so it would work on Windows systems.